### PR TITLE
Support for MongoDB 4.x and k8s 1.16+

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,4 +10,4 @@ services:
     restart: always
 
   mongodb:
-    image: bitnami/mongodb:4.2.3-r2
+    image: bitnami/mongodb:4.2.6

--- a/helm/todo/requirements.lock
+++ b/helm/todo/requirements.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: mongodb
-  repository: https://kubernetes-charts.storage.googleapis.com
-  version: 0.4.7
-digest: sha256:7482d8244680d146a5471de52247f72d4572aec306c31b0c014c5a1f88f9a5dd
-generated: "2020-01-27T15:26:47.459112847-08:00"
+  repository: https://charts.bitnami.com/bitnami
+  version: 7.14.1
+digest: sha256:2658020af69484c91ea9e9bf51ee8f15742c6466a91d15f194de661eb8474734
+generated: "2020-05-12T10:57:43.393292426-07:00"

--- a/helm/todo/requirements.yaml
+++ b/helm/todo/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
 - name: mongodb
-  version: 0.4.7
-  repository: https://kubernetes-charts.storage.googleapis.com
+  version: 7.14.1
+  repository: https://charts.bitnami.com/bitnami

--- a/helm/todo/templates/deployment.yaml
+++ b/helm/todo/templates/deployment.yaml
@@ -1,4 +1,4 @@
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: {{ template "fullname" . }}
@@ -6,10 +6,15 @@ metadata:
     chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
 spec:
   replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ template "fullname" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:
         app: {{ template "fullname" . }}
+        release: {{ .Release.Name }}
     spec:
       containers:
       - name: {{ .Chart.Name }}

--- a/helm/todo/values.yaml
+++ b/helm/todo/values.yaml
@@ -22,3 +22,7 @@ ingress:
   host: todos.local
   # Enable automatic TLS with Let's Encrypt
   tls: true
+
+mongodb:
+  # Disable authentication TODO(change) only for demo purposes
+  usePassword: false


### PR DESCRIPTION
The deployment was not compatible with K8s 1.16+ neither MongoDB 4.x. For the former I updated the deployment template in the chart i.e `apiVersion: apps/v1` and for the latter I needed to take into account that the chart generates a random password at boot. 

For now, and since this is for demo purposes I've disabled the auth in MongoDB but we could use the autogenerated password instead in following PRs 
